### PR TITLE
remove unused directory, fixes cmake error

### DIFF
--- a/gr-rccar2/CMakeLists.txt
+++ b/gr-rccar2/CMakeLists.txt
@@ -145,7 +145,7 @@ add_custom_target(uninstall
 # Add subdirectories
 ########################################################################
 add_subdirectory(include/rccar2)
-add_subdirectory(lib)
+#add_subdirectory(lib)
 add_subdirectory(swig)
 add_subdirectory(python)
 add_subdirectory(grc)


### PR DESCRIPTION
CMake Error at CMakeLists.txt:148 (add_subdirectory):
  add_subdirectory given source "lib" which is not an existing directory.
